### PR TITLE
Use `authorize_upgrade` on Relay Chains

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -122,6 +122,7 @@ fn upgrade_args_for_only_relay() -> UpgradeArgs {
 	UpgradeArgs {
 		network: String::from("polkadot"),
 		only: true,
+		set_relay_directly: true,
 		relay_version: Some(String::from("v1.2.0")),
 		asset_hub: None,
 		bridge_hub: None,
@@ -137,6 +138,7 @@ fn upgrade_args_for_only_asset_hub() -> UpgradeArgs {
 	UpgradeArgs {
 		network: String::from("polkadot"),
 		only: true,
+		set_relay_directly: true,
 		relay_version: None,
 		asset_hub: Some(String::from("v1.2.0")),
 		bridge_hub: None,
@@ -152,6 +154,7 @@ fn upgrade_args_for_all() -> UpgradeArgs {
 	UpgradeArgs {
 		network: String::from("polkadot"),
 		only: false,
+		set_relay_directly: true,
 		relay_version: Some(String::from("v1.2.0")),
 		asset_hub: None,
 		bridge_hub: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -140,6 +140,8 @@ pub(super) struct UpgradeDetails {
 	pub(super) output_file: String,
 	// An additional call to be enacted in the same batch as the system upgrade.
 	pub(super) additional: Option<CallInfo>,
+	// Call `set_code` directly on the Relay Chain.
+	pub(super) set_relay_directly: bool,
 }
 
 // A network and the version to which it will upgrade.


### PR DESCRIPTION
Until `SafeCallFilter`s are removed from parachains, but we should be able to start with this right away.