### PR TITLE
Add polkadot people chain

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -490,6 +490,7 @@ fn upgrade_everything_works_with_just_relay_version() {
 		VersionedNetwork { network: Network::PolkadotAssetHub, version: String::from("1.2.0") },
 		VersionedNetwork { network: Network::PolkadotCollectives, version: String::from("1.2.0") },
 		VersionedNetwork { network: Network::PolkadotBridgeHub, version: String::from("1.2.0") },
+		VersionedNetwork { network: Network::PolkadotPeople, version: String::from("1.2.0") },
 	];
 	assert_eq!(details.networks, expected_networks);
 	assert!(details.additional.is_none());


### PR DESCRIPTION
Allows building an upgrade for the Polkdot network including the People chain.

Also bumps the Kusama OriginKind to v3 after its upgrade to v1.3.0.